### PR TITLE
Fix `on_fail` webhook model to follow CP API

### DIFF
--- a/lib/cloud_payments/models/on_fail.rb
+++ b/lib/cloud_payments/models/on_fail.rb
@@ -1,33 +1,29 @@
 module CloudPayments
+  # @see https://cloudpayments.ru/Docs/Notifications#fail CloudPayments API
   class OnFail < Model
     property :id, from: :transaction_id, required: true
     property :amount, transform_with: DecimalTransform, required: true
     property :currency, required: true
+    property :date_time, transform_with: DateTimeTransform
+    property :card_first_six, required: true
+    property :card_last_four, required: true
+    property :card_type, required: true
+    property :card_exp_date, required: true
+    property :test_mode, required: true
+    property :reason, required: true
+    property :reason_code, required: true
     property :invoice_id
     property :account_id
     property :subscription_id
+    property :name
     property :email
-    property :description
-    property :metadata, from: :data, default: {}
-    property :date_time, transform_with: DateTimeTransform
-    property :test_mode, required: true
     property :ip_address
     property :ip_country
     property :ip_city
     property :ip_region
     property :ip_district
-    property :ip_lat, from: :ip_latitude
-    property :ip_lng, from: :ip_longitude
-    property :card_first_six, required: true
-    property :card_last_four, required: true
-    property :card_type, required: true
-    property :card_type_code
-    property :card_exp_date
-    property :name
     property :issuer_bank_country
-    property :status, required: true
-    property :status_code
-    property :reason
-    property :reason_code
+    property :description
+    property :metadata, from: :data, default: {}
   end
 end

--- a/spec/cloud_payments/webhooks_spec.rb
+++ b/spec/cloud_payments/webhooks_spec.rb
@@ -182,14 +182,11 @@ describe CloudPayments::Webhooks do
     specify { expect(subject.ip_city).to eq 'Санкт-Петербург' }
     specify { expect(subject.ip_region).to eq 'Санкт-Петербург' }
     specify { expect(subject.ip_district).to eq 'Северо-Западный федеральный округ' }
-    specify { expect(subject.ip_lat).to eq '59.939037' }
-    specify { expect(subject.ip_lng).to eq '30.315784' }
     specify { expect(subject.card_first_six).to eq '400005' }
     specify { expect(subject.card_last_four).to eq '5556' }
     specify { expect(subject.card_type).to eq 'Visa' }
     specify { expect(subject.card_exp_date).to eq '01/19' }
     specify { expect(subject.description).to eq 'Оплата в example.com' }
-    specify { expect(subject.status).to eq 'Declined' }
   end
 
   describe 'on_recurrent' do


### PR DESCRIPTION
Remove attributes that not supported by API, namely:
- status
- status_code
- ip_lat
- ip_lng
- card_type_code

See https://cloudpayments.ru/Docs/Notifications#fail for details.
